### PR TITLE
locking setupstools-scm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=69", "setuptools-scm>=8,<9"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
# 📦 Pull Request

Thank you for contributing to the LPD Filter!

Please fill out this form to help us understand your change.

---

## 📋 What does this PR do?

- Locks setupstools-scm version between 8 and 9

---

## 🔍 Why is this needed?

- setupstools-scm v9 has some breaking changes

---

## 🧪 How was it tested?

- Locally and via CI
---

## ✅ Checklist

- [x] I have read and agreed to the terms of the [LICENSE](../LICENSE)
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I have followed the [coding style](../CONTRIBUTING.md#coding-style)
- [x] I have signed all commits in compliance with the DCO (`git commit -s`)
- [x] I have added or updated **tests** as needed
- [x] I have added or updated **documentation** as needed

> 📄 **DCO Reminder:**  
> All commits must be signed with the [Developer Certificate of Origin](https://developercertificate.org/).  
> You can automatically sign commits using:
>
> ```bash
> git commit -s -m "Your commit message"
> ```

---

_Thanks for contributing to the OCR Filter! We’ll review your PR as soon as possible._
