### PR TITLE
fix: repair model artifact download

### DIFF
--- a/.github/workflows/model-artifact-check.yaml
+++ b/.github/workflows/model-artifact-check.yaml
@@ -18,7 +18,8 @@ jobs:
   check-artifact:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: {}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/model-artifact-check.yaml
+++ b/.github/workflows/model-artifact-check.yaml
@@ -11,6 +11,10 @@ name: Model Artifact Check
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'Makefile'
+      - '.github/workflows/model-artifact-check.yaml'
   schedule:
     - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
 

--- a/.github/workflows/model-artifact-check.yaml
+++ b/.github/workflows/model-artifact-check.yaml
@@ -1,0 +1,31 @@
+name: Model Artifact Check
+
+# Guards against a repeat of FILTER-648: the public model URL 404'd for
+# ~a year with no CI ever noticing, because `make install` only runs the
+# download step when model.pth is already missing from the runner.
+# This check always re-fetches, independent of the Makefile target.
+#
+# The URL here is intentionally hardcoded to match the Makefile's
+# `download-model` target (openfilter/examples/hello-world uses the same
+# URL) — if one changes, update the other.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
+
+jobs:
+  check-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download model archive (follow redirects, fail on non-2xx)
+        run: |
+          curl -fL --retry 2 --retry-delay 5 \
+            -o model.zip \
+            https://storage.googleapis.com/plainsight-ml-assets-production/models/license_plate_detection_model_v0.1.0.zip
+
+      - name: Verify archive is a valid zip
+        run: unzip -t model.zip
+
+      - name: Verify model.pth is present in the archive
+        run: unzip -l model.zip | grep -q 'model\.pth$'

--- a/.github/workflows/model-artifact-check.yaml
+++ b/.github/workflows/model-artifact-check.yaml
@@ -1,13 +1,13 @@
 name: Model Artifact Check
 
-# Guards against a repeat of FILTER-648: the public model URL 404'd for
-# ~a year with no CI ever noticing, because `make install` only runs the
-# download step when model.pth is already missing from the runner.
-# This check always re-fetches, independent of the Makefile target.
+# Guards against the public model download breaking without CI noticing.
+# `make install` only re-downloads when model.pth is missing locally, so a
+# broken URL can go undetected indefinitely — no other job in this repo
+# exercises the download.
 #
-# The URL here is intentionally hardcoded to match the Makefile's
-# `download-model` target (openfilter/examples/hello-world uses the same
-# URL) — if one changes, update the other.
+# This job runs the actual `download-model` recipe consumers use, so it
+# fails the same way a real install would rather than checking a separate
+# copy of the logic.
 
 on:
   workflow_dispatch:
@@ -17,15 +17,16 @@ on:
 jobs:
   check-artifact:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: {}
     steps:
-      - name: Download model archive (follow redirects, fail on non-2xx)
-        run: |
-          curl -fL --retry 2 --retry-delay 5 \
-            -o model.zip \
-            https://storage.googleapis.com/plainsight-ml-assets-production/models/license_plate_detection_model_v0.1.0.zip
+      - uses: actions/checkout@v4
 
-      - name: Verify archive is a valid zip
-        run: unzip -t model.zip
+      - name: Download model via the consumer recipe
+        run: make download-model
 
-      - name: Verify model.pth is present in the archive
-        run: unzip -l model.zip | grep -q 'model\.pth$'
+      - name: Verify model.pth exists
+        run: test -f model.pth
+
+      - name: Verify model.pth integrity
+        run: echo "ab6a6639042b7e66d38d738b9a35fe95058b989d8e0f5e6f6f90276a8ea3c605  model.pth" | sha256sum -c -

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 download-model:
 	@if [ ! -f model.pth ]; then \
 		echo "model not found, downloading model archive..." && \
-		curl -fL -o model.zip https://storage.googleapis.com/plainsight-ml-assets-production/models/license_plate_detection_model_v0.1.0.zip && \
+		curl -fL --retry 2 --retry-delay 5 -o model.zip https://storage.googleapis.com/plainsight-ml-assets-production/models/license_plate_detection_model_v0.1.0.zip && \
 		echo "Unzipping model archive to current directory..." && \
 		unzip -o model.zip && \
 		echo "Removing model.zip..." && \

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ help:
 .PHONY: download-model
 download-model:
 	@if [ ! -f model.pth ]; then \
-		echo "model not found, downloading model archive..."; \
-		curl -L -o model.zip https://models.openfilter.io/license_plate_detection_model/v0.1.0.zip; \
-		echo "Unzipping model archive to current directory..."; \
-		unzip -o model.zip; \
-		echo "Removing model.zip..."; \
+		echo "model not found, downloading model archive..." && \
+		curl -fL -o model.zip https://storage.googleapis.com/plainsight-ml-assets-production/models/license_plate_detection_model_v0.1.0.zip && \
+		echo "Unzipping model archive to current directory..." && \
+		unzip -o model.zip && \
+		echo "Removing model.zip..." && \
 		rm model.zip; \
 	else \
 		echo "model already exists, skipping download."; \


### PR DESCRIPTION
Fixes [FILTER-648](https://plainsight-ai.atlassian.net/browse/FILTER-648)

The public model URL (`models.openfilter.io`) has been returning a 404. `make install` only downloads the model when `model.pth` is missing locally, so CI never caught this.

Found the model artifact still available at the canonical public GCS location (`storage.googleapis.com/plainsight-ml-assets-production/...`). Confirmed it's a valid archive, contains `model.pth`, and loads cleanly against the current filter's model architecture. Switched the install step to use that URL directly.

Hardened the download recipe too: a failed download or a corrupt archive now fails the build instead of leaving a missing or stale `model.pth` behind silently. Added a weekly workflow that runs the actual `make download-model` recipe and verifies the resulting artifact, so a future break gets caught automatically.

[FILTER-648]: https://plainsight-ai.atlassian.net/browse/FILTER-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ